### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -17,3 +17,4 @@ explicit
 
 call-if : boost-library headers
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,19 @@
+# Copyright René Ferdinand Rivera Morell 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/headers
+    ;
+
+explicit
+    [ alias boost_headers : build//boost_headers ]
+    [ alias install : build//install ]
+    [ alias stage : build//stage ]
+    [ alias all : boost_headers stage ]
+    ;
+
+call-if : boost-library headers
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/headers
     ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/headers

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -2,7 +2,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
+require-b2 5.2 ;
 
 import package ;
 import path ;

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -2,12 +2,16 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import package ;
 import path ;
 import sequence ;
 import set ;
-import ../../../tools/boost_install/boost-install ;
-import ../../../tools/boost_install/boost-install-dirs ;
+
+import-search /boost/boost_install ;
+import boost-install ;
+import boost-install-dirs ;
 
 # install-header-subdir
 

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -8,37 +8,39 @@ import package ;
 import path ;
 import sequence ;
 import set ;
+import project ;
+import regex ;
 
 import-search /boost/boost_install ;
 import boost-install ;
 import boost-install-dirs ;
 
+path-constant LIBS_ROOT : ../.. ;
+
 # install-header-subdir
 
 local header-subdir = [ boost-install-dirs.header-subdir ] ;
 
-local install-header-subdir ;
+local install-header-subdir = $(header-subdir)/boost ;
+install-header-subdir ?= boost ;
 
-if $(header-subdir)
-{
-    install-header-subdir = $(header-subdir)/boost ;
-}
-else
-{
-    install-header-subdir = boost ;
-}
+ECHO "[INFO] install-header-subdir:" $(install-header-subdir) ;
 
 # install-headers
 
 # first, the 'modular' headers
 
-local modular-headers = $(BOOST_MODULARLAYOUT) ;
+local modular-headers
+    = [ SORT [ MATCH .*libs/(.*)/include/boost : [ glob
+        $(LIBS_ROOT)/*/include/boost
+        $(LIBS_ROOT)/numeric/*/include/boost
+        ] ] ] ;
 
 local skip-headers ;
 
 for local lib in $(modular-headers)
 {
-    local header-root = $(BOOST_ROOT)/libs/$(lib)/include/boost ;
+    local header-root = $(LIBS_ROOT)/$(lib)/include/boost ;
 
     local headers =
         [ path.glob-tree $(header-root) : *.hpp *.ipp *.h *.inc ]
@@ -60,11 +62,16 @@ for local lib in $(modular-headers)
 
 # then, the non-modular headers in boost/, minus the modular ones
 
-local header-root = [ path.make $(BOOST_ROOT)/boost ] ;
+local headers ;
 
-local headers =
-    [ path.glob-tree $(BOOST_ROOT)/boost : *.hpp *.ipp *.h *.inc ]
-    [ path.glob-tree $(BOOST_ROOT)/boost/compatibility/cpp_c_headers : c* ] ;
+if $(BOOST_ROOT)
+{
+    local header-root = [ path.make $(BOOST_ROOT)/boost ] ;
+
+    headers =
+        [ path.glob-tree $(BOOST_ROOT)/boost : *.hpp *.ipp *.h *.inc ]
+        [ path.glob-tree $(BOOST_ROOT)/boost/compatibility/cpp_c_headers : c* ] ;
+}
 
 headers = [ set.difference $(headers) : $(header-root)/$(skip-headers) ] ;
 
@@ -78,6 +85,26 @@ package.install install-boost-headers Boost
 ;
 
 explicit install-boost-headers ;
+
+# Boost version format: XYYYZZ
+
+if ! [ modules.peek boostcpp : BOOST_VERSION ]
+{
+    local boost-config = [ project.search /boost/config ] ;
+    ECHO "[INFO] boost-config:" $(boost-config) ;
+    if $(boost-config)
+    {
+        local boost-version-num = [ regex.grep
+            [ path.native [ path.join $(boost-config) include boost ] ]
+            : version.hpp : "BOOST_VERSION ([0-9]+)" : 1 ] ;
+        boost-version-num = [ MATCH "(.*)(...)(..)" : $(boost-version-num[2]) ] ;
+        boost-version-num =
+            [ CALC $(boost-version-num[1]) + 0 ]
+            [ CALC $(boost-version-num[2]) + 0 ]
+            [ CALC $(boost-version-num[3]) + 0 ] ;
+        modules.poke boostcpp : BOOST_VERSION : $(boost-version-num:J=.) ;
+    }
+}
 
 #
 


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.